### PR TITLE
Restricted initial record lookup to A records only

### DIFF
--- a/CloudFlareDynDns/CloudFlareDynDns.psm1
+++ b/CloudFlareDynDns/CloudFlareDynDns.psm1
@@ -105,7 +105,7 @@ Function Update-CloudFlareDynamicDns
 	if ($cfzone.result.count -gt 0) { $zoneid = $cfzone.result.id } else { throw "Zone $zone does not exist" }
 	
 	Write-Output "Getting current IP for $hostname"
-	$recordurl = $baseurl+'/'+$zoneid+'/dns_records/?name='+$hostname+'&type=A'
+	$recordurl = "$baseurl/$zoneid/dns_records/?name=$hostname&type=A"
 	
 	if ($usedns -eq $true) { 
 		try { 

--- a/CloudFlareDynDns/CloudFlareDynDns.psm1
+++ b/CloudFlareDynDns/CloudFlareDynDns.psm1
@@ -105,7 +105,7 @@ Function Update-CloudFlareDynamicDns
 	if ($cfzone.result.count -gt 0) { $zoneid = $cfzone.result.id } else { throw "Zone $zone does not exist" }
 	
 	Write-Output "Getting current IP for $hostname"
-	$recordurl = "$baseurl/$zoneid/dns_records/?name=$hostname"
+	$recordurl = $baseurl+'/'+$zoneid+'/dns_records/?name='+$hostname+'&type=A'
 	
 	if ($usedns -eq $true) { 
 		try { 


### PR DESCRIPTION
If a CAA record exists/iscreated after the initial A record, which in all likelyhood it typically is, this script will be returned that record from Cloudflare and attempt to update a CAA record with A record values, which fails.
This restricts the initial look up to A records so that it doesn't encounter this any longer.